### PR TITLE
Add extensions option for self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,32 @@ only two new environment variables be introduced.
 - CN: the **Common Name** fields of the certificate, default is localhosta
 - DIRECTORY: You can get the self-signed certificated files when you set this value, the script will copy those files into this location and you should also mount the volume into the container.
 
-You can use the following command to start a registry with self-signed certificate
+You can use the following command to start a registry with self-signed certificate.
+- Use CN with domain name
 ```sh
-docker run -v `pwd`:/certs REGISTRY_HTTP_ADDR=0.0.0.0:443 -p 443:443 DIRECTORY=/certs -e CN=192.168.0.106 hwchiu/self-signed-docker-registry
+$ docker run \
+--restart always \
+--name registry \
+-v `pwd`:/certs \
+-e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
+-e DIRECTORY=/certs \
+-e CN=domainname \
+-v /mnt/registry:/var/lib/registry \
+-p 443:443 \
+hwchiu/self-signed-docker-registry
+```
+- Use CN with specified IP address
+```sh
+$ docker run \
+--restart always \
+--name registry \
+-v `pwd`:/certs \
+-e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
+-e DIRECTORY=/certs \
+-e CN=192.168.0.106 \
+-v /mnt/registry:/var/lib/registry \
+-p 443:443 \
+hwchiu/self-signed-docker-registry
 ```
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,13 +2,36 @@
 echo $@
 set -e
 
+check_ip()
+{
+    IP=$1
+    VALID_CHECK=$(echo $IP|awk -F. '$1<=255&&$2<=255&&$3<=255&&$4<=255{print "yes"}')
+    if echo $IP|grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$">/dev/null; then
+        if [ ${VALID_CHECK:-no} == "yes" ]; then
+            echo "IP $IP available."
+            return 0
+        else
+            echo "IP $IP not available!"
+            return 1
+        fi
+    else
+        echo "IP format error!"
+        return 1
+    fi
+}
+
 create_certificate()
 {
 WORKDIR=/
 KEYPATH=${WORKDIR}${KEY_OUTPUT}
 CERTPATH=${WORKDIR}${OUTPUT}
 sed -ie "s/@CN@/$CN/g" req.cnf
-openssl req -newkey rsa:4096 -nodes -sha256 -keyout ${KEYPATH} -x509 -days 36500 -out ${CERTPATH} -config req.cnf
+check_ip $CN
+if [ $? -eq 0 ]; then
+    openssl req -newkey rsa:4096 -nodes -sha256 -keyout ${KEYPATH} -x509 -days 36500 -out ${CERTPATH} -config req.cnf -extensions v3_ca
+else
+    openssl req -newkey rsa:4096 -nodes -sha256 -keyout ${KEYPATH} -x509 -days 36500 -out ${CERTPATH} -config req.cnf
+fi
 export REGISTRY_HTTP_TLS_CERTIFICATE=${CERTPATH}
 export REGISTRY_HTTP_TLS_KEY=${KEYPATH}
 


### PR DESCRIPTION
Generate certificate with the specified IP address ([`-extensions v3_ca`](https://github.com/hwchiu/self-signed-docker-registry/blob/master/req.cnf#L15-L16)).
**I haven't tested this yet. Will do this tomorrow.**